### PR TITLE
Bump actions/setup-go to v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Go 1.20
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: '>=1.20.0'
         cache-dependency-path: ${{ github.action_path }}/go.sum


### PR DESCRIPTION
Update actions/setup-go to v5 to solve the node16 deprecation warning when using depot in a github actions workflow step